### PR TITLE
[MAIN] CN-1348: PHP 8.5 compatibility fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,8 @@
 TradeCentric - Purchase Order
 ===========
+### 3.0.16 (2026-08-03)
+* CN-1348: Added support for PHP 8.5 compatibility with Magento 2.4.9
+
 ### 3.0.14 (2025-08-12)
 * PBR-2419: Added support for PHP 8.4 compatibility with Magento 2.4.8
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -56,7 +56,7 @@ class Data extends AbstractHelper
             ScopeInterface::SCOPE_STORE,
             $storeId
         );
-        return strlen($value) ? $value : '';
+        return strlen((string) $value) ? (string) $value : '';
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "OSL-3.0",
     "AFL-3.0"
   ],
-  "version": "3.0.15",
+  "version": "3.0.16",
   "require": {
     "php": "^7.0||^8.0",
     "tradecentric/module-version": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca71d5383707bf4cca5b26fceba2439c",
+    "content-hash": "2c38f88fbb92e0f9fc7b12bdb2a02be0",
     "packages": [
         {
             "name": "tradecentric/module-punchout",
@@ -675,5 +675,5 @@
         "php": "^7.0||^8.0"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
## Summary
- Guard nullable config value with a `(string)` cast before passing to `strlen()`, avoiding a PHP 8.1+ deprecation notice that surfaces more loudly on PHP 8.5.

## Test plan
- Verified `bin/magento setup:di:compile` succeeds on PHP 8.5 + Adobe Commerce 2.4.9.
- See CN-1348 for full compatibility test plan across affected modules.